### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Helm linter
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint charts


### PR DESCRIPTION
Potential fix for [https://github.com/safespring-community/certmanager-webhook-rcodezero/security/code-scanning/1](https://github.com/safespring-community/certmanager-webhook-rcodezero/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (root) to explicitly define the required permissions. Since the workflow only performs linting operations, it does not need write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs within the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
