### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish_charts.yml
+++ b/.github/workflows/publish_charts.yml
@@ -1,5 +1,8 @@
 name: Publish charts
 
+permissions:
+  contents: write
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/safespring-community/certmanager-webhook-rcodezero/security/code-scanning/2](https://github.com/safespring-community/certmanager-webhook-rcodezero/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's steps, the `chart-releaser` action likely requires `contents: write` to update the repository with the released charts. Other permissions will be set to `read` or omitted entirely if not needed. This ensures that the workflow has only the permissions it requires to function correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
